### PR TITLE
Update FindLibPortAudio.cmake

### DIFF
--- a/cmake/FindLibPortAudio.cmake
+++ b/cmake/FindLibPortAudio.cmake
@@ -19,88 +19,70 @@ if (PORTAUDIO_LIBRARIES AND PORTAUDIO_INCLUDE_DIRS)
   set(PORTAUDIO_FOUND TRUE)
 else (PORTAUDIO_LIBRARIES AND PORTAUDIO_INCLUDE_DIRS)
   if (NOT WIN32)
-   include(FindPkgConfig)
-   pkg_check_modules(PORTAUDIO2 portaudio-2.0)
+    include(FindPkgConfig)
+    pkg_check_modules(PORTAUDIO2 portaudio-2.0)
   endif (NOT WIN32)
 
-  if (PORTAUDIO2_FOUND)
-    set(PORTAUDIO_INCLUDE_DIRS
-      ${PORTAUDIO2_INCLUDE_DIRS}
-    )
-    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-      set(PORTAUDIO_LIBRARIES "${PORTAUDIO2_LIBRARY_DIRS}/lib${PORTAUDIO2_LIBRARIES}.dylib")
-    else (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-      set(PORTAUDIO_LIBRARIES
-        ${PORTAUDIO2_LIBRARIES}
-      )
-    endif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(PORTAUDIO_VERSION
-      19
-    )
-    set(PORTAUDIO_FOUND TRUE)
-  else (PORTAUDIO2_FOUND)
-    find_path(PORTAUDIO_INCLUDE_DIR
-      NAMES
-        portaudio.h
+  find_path (PORTAUDIO_INCLUDE_DIRS
+    NAMES
+      portaudio.h
       PATHS
+        ${PORTAUDIO2_INCLUDEDIR}
         /usr/include
         /usr/local/include
         /opt/local/include
         /sw/include
     )
-
-    find_library(PORTAUDIO_LIBRARY
-      NAMES
-        portaudio
-      PATHS
-        /usr/lib
-        /usr/local/lib
-        /opt/local/lib
-        /sw/lib
+  if (NOT PORTAUDIO_INCLUDE_DIRS)
+    set (PORTAUDIO_INCLUDE_DIRS
+      ${PORTAUDIO2_INCLUDE_DIRS}
     )
+    list (APPEND PORTAUDIO_INCLUDE_DIRS ${PORTAUDIO2_INCLUDEDIR})
+  endif (NOT PORTAUDIO_INCLUDE_DIRS)
 
-    find_path(PORTAUDIO_LIBRARY_DIR
-      NAMES
-        portaudio
-      PATHS
-        /usr/lib
-        /usr/local/lib
-        /opt/local/lib
-        /sw/lib
+  find_library (PORTAUDIO_LIBRARIES
+    NAMES
+      portaudio
+    PATHS
+      ${PORTAUDIO2_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+  if (NOT PORTAUDIO_LIBRARIES)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      set(PORTAUDIO_LIBRARIES "${PORTAUDIO2_LIBDIR}/lib${PORTAUDIO2_LIBRARIES}.dylib")
+    else (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      set(PORTAUDIO_LIBRARIES
+        ${PORTAUDIO2_LIBRARIES}
     )
+    endif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  endif (NOT PORTAUDIO_LIBRARIES)
 
-    set(PORTAUDIO_INCLUDE_DIRS
-      ${PORTAUDIO_INCLUDE_DIR}
+  if (PORTAUDIO2_VERSION)
+    set(PORTAUDIO_VERSION
+      ${PORTAUDIO2_VERSION}
     )
-    set(PORTAUDIO_LIBRARIES
-      ${PORTAUDIO_LIBRARY}
-    )
-
-    set(PORTAUDIO_LIBRARY_DIRS
-      ${PORTAUDIO_LIBRARY_DIR}
-    )
-
+  else (PORTAUDIO2_VERSION)
     set(PORTAUDIO_VERSION
       18
     )
+  endif (PORTAUDIO2_VERSION)
 
-    if (PORTAUDIO_INCLUDE_DIRS AND PORTAUDIO_LIBRARIES)
-       set(PORTAUDIO_FOUND TRUE)
-    endif (PORTAUDIO_INCLUDE_DIRS AND PORTAUDIO_LIBRARIES)
-
-    if (PORTAUDIO_FOUND)
-      if (NOT Portaudio_FIND_QUIETLY)
-        message(STATUS "Found Portaudio: ${PORTAUDIO_LIBRARIES}")
-      endif (NOT Portaudio_FIND_QUIETLY)
-    else (PORTAUDIO_FOUND)
-      if (Portaudio_FIND_REQUIRED)
-        message(FATAL_ERROR "Could not find Portaudio")
-	 else (Portaudio_FIND_REQUIRED)
-        message(STATUS "Could NOT find Portaudio")
-      endif (Portaudio_FIND_REQUIRED)
-    endif (PORTAUDIO_FOUND)
-  endif (PORTAUDIO2_FOUND)
-
+  if (PORTAUDIO_INCLUDE_DIRS AND PORTAUDIO_LIBRARIES)
+     set(PORTAUDIO_FOUND TRUE)
+  endif (PORTAUDIO_INCLUDE_DIRS AND PORTAUDIO_LIBRARIES)
+ 
+  if (PORTAUDIO_FOUND)
+    if (NOT Portaudio_FIND_QUIETLY)
+      message(STATUS "Found Portaudio: ${PORTAUDIO_LIBRARIES}")
+    endif (NOT Portaudio_FIND_QUIETLY)
+  else (PORTAUDIO_FOUND)
+    if (Portaudio_FIND_REQUIRED)
+      message(FATAL_ERROR "Could not find Portaudio")
+    endif (Portaudio_FIND_REQUIRED)
+  endif (PORTAUDIO_FOUND)
 
   # show the PORTAUDIO_INCLUDE_DIRS and PORTAUDIO_LIBRARIES variables only in the advanced view
   mark_as_advanced(PORTAUDIO_INCLUDE_DIRS PORTAUDIO_LIBRARIES)


### PR DESCRIPTION
Bonjour cher OM,

Je me permets de vous proposer cette modification afin de corriger un problème lors de la compilation sur MacOS, et probablement Linux aussi. Il s'agit d'un bug avec portaudio, j'ai récupéré le code auprès du programme original.

En espérant avoir pu vous aider.

73's de F4HWD Maxime :)