### PR TITLE
Fix pre-existing bugs in MBE file handling and QPSK jitter

### DIFF
--- a/src/dsd_file.c
+++ b/src/dsd_file.c
@@ -135,6 +135,7 @@ void openMbeInFile (dsd_opts * opts, dsd_state * state)
   if (opts->mbe_in_f == NULL)
   {
     fprintf(stderr, "Error: could not open %s\n", opts->mbe_in_file);
+    return;
   }
 
   // read cookie
@@ -162,14 +163,11 @@ void openMbeInFile (dsd_opts * opts, dsd_state * state)
 void closeMbeOutFile (dsd_opts * opts, dsd_state * state)
 {
 
-  char shell[255], newfilename[64], ext[5], datestr[32], new_path[1024];
+  char newfilename[128], ext[5], datestr[32], new_path[1024];
   char tgid[17];
   int sum, i, j;
   int talkgroup;
   struct tm timep;
-  int result = 0;
-
-  UNUSED_VARIABLE(result);
 
   if (opts->mbe_out_f != NULL)
   {
@@ -207,14 +205,12 @@ void closeMbeOutFile (dsd_opts * opts, dsd_state * state)
     fclose (opts->mbe_out_f);
     opts->mbe_out_f = NULL;
     strftime (datestr, 31, "%Y-%m-%d-%H%M%S", &timep);
-    sprintf(newfilename, "nac%X-%s-tg%i%s", state->nac, datestr, talkgroup, ext);
-    sprintf(new_path, "%s%s", opts->mbe_out_dir, newfilename);
-#ifdef _WIN32
-    sprintf(shell, "move %s %s", opts->mbe_out_path, new_path);
-#else
-    sprintf(shell, "mv %s %s", opts->mbe_out_path, new_path);
-#endif
-    result = system (shell);
+    snprintf(newfilename, sizeof(newfilename), "nac%X-%s-tg%i%s", state->nac, datestr, talkgroup, ext);
+    snprintf(new_path, sizeof(new_path), "%s%s", opts->mbe_out_dir, newfilename);
+    if (rename (opts->mbe_out_path, new_path) != 0)
+    {
+      fprintf(stderr, "Error: could not rename %s to %s\n", opts->mbe_out_path, new_path);
+    }
 
     state->tgcount = 0;
     for (i = 0; i < 25; i++)
@@ -244,7 +240,7 @@ void openMbeOutFile (dsd_opts * opts, dsd_state * state)
   }
 
   //  reset talkgroup id buffer
-  for (i = 0; i < 12; i++)
+  for (i = 0; i < 16; i++)
   {
     for (j = 0; j < 25; j++)
     {
@@ -263,6 +259,7 @@ void openMbeOutFile (dsd_opts * opts, dsd_state * state)
   if (opts->mbe_out_f == NULL)
   {
     fprintf(stderr, "Error, couldn't open %s\n", opts->mbe_out_path);
+    return;
   }
 
   // write magic

--- a/src/dsd_symbol.c
+++ b/src/dsd_symbol.c
@@ -55,7 +55,7 @@ int getSymbol (dsd_opts * opts, dsd_state * state, int have_sync)
         {
           i++;          // fall back
         }
-        else if ((state->jitter > state->symbolCenter) && (state->jitter < state->symbolCenter))
+        else if ((state->jitter > state->symbolCenter) && (state->jitter < state->samplesPerSymbol))
         {
           i--;          // catch up
         }


### PR DESCRIPTION
## Summary

- **NULL dereference in `openMbeInFile` / `openMbeOutFile`**: Both functions printed an error on `fopen` failure but continued execution, dereferencing NULL file pointers. Added early `return` after error.
- **Buffer overflow in `closeMbeOutFile`**: Replaced `sprintf` with `snprintf` for `newfilename` and `new_path` to prevent overflows.
- **Command injection in `closeMbeOutFile`**: Replaced `system("mv ...")` with `rename()` — eliminates shell injection via crafted filenames and removes shell dependency.
- **`tg` array init bounds in `openMbeOutFile`**: Loop used `i < 12` but `tg` is dimensioned `[25][16]`. Fixed to `i < 16`.
- **Dead QPSK jitter code in `getSymbol`**: The condition `jitter >= 0 && jitter < symbolCenter` was unreachable because `jitter` is only set when `i >= symbolCenter`. Changed to `jitter < samplesPerSymbol` to match the intended range check.